### PR TITLE
web3.swift version updated

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "KeychainSwift", url: "https://github.com/evgenyneu/keychain-swift.git", from: "20.0.0"),
-        .package(name: "web3.swift", url: "https://github.com/argentlabs/web3.swift", from: "0.9.3"),
+        .package(name: "web3.swift", url: "https://github.com/argentlabs/web3.swift", from: "1.1.0"),
         .package(name: "CryptoSwift", url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.5.1"),
         .package(name:"SessionManager",url: "https://github.com/Web3Auth/session-manager-swift.git",from: "2.0.0")
     ],


### PR DESCRIPTION
web3.swift was using a older version which was causing issues with other packages like bigInt, upgraded the package with the latest version of web3.swift