### PR TITLE
Make name optional

### DIFF
--- a/Sources/Web3Auth/Web3Auth.swift
+++ b/Sources/Web3Auth/Web3Auth.swift
@@ -154,6 +154,8 @@ public class Web3Auth: NSObject {
                         let callbackURL = callbackURL,
                         let sessionId = try? Web3Auth.decodeSessionStringfromCallbackURL(callbackURL)
                     else {
+
+                        print("Failed to decode decodeSessionStringfromCallbackURL")
                         let authError = authError ?? Web3AuthError.unknownError
                         if case ASWebAuthenticationSessionError.canceledLogin = authError {
                             continuation.resume(throwing: Web3AuthError.userCancelled)
@@ -174,6 +176,8 @@ public class Web3Auth: NSObject {
                             self.state = loginDetails
                             return continuation.resume(returning: loginDetails)
                         } catch {
+                            print("Failed to get login details");
+                            print("Error: \(error.localizedDescription)")
                             continuation.resume(throwing: Web3AuthError.unknownError)
                         }
                     }
@@ -182,6 +186,7 @@ public class Web3Auth: NSObject {
             authSession?.presentationContextProvider = self
 
             if !(authSession?.start() ?? false) {
+                print("Auth session start failed");
                 continuation.resume(throwing: Web3AuthError.unknownError)
             }
         })

--- a/Sources/Web3Auth/Web3Auth.swift
+++ b/Sources/Web3Auth/Web3Auth.swift
@@ -168,7 +168,9 @@ public class Web3Auth: NSObject {
                     self.sessionManager.setSessionID(sessionId)
                     Task {
                         do {
+                            print("start get login details \(callbackURL)");
                             let loginDetails = try await self.getLoginDetails(callbackURL)
+                            print("end get login details");
                             if let safeUserInfo = loginDetails.userInfo {
                                 KeychainManager.shared.saveDappShare(userInfo: safeUserInfo)
                             }

--- a/Sources/Web3Auth/Web3Auth.swift
+++ b/Sources/Web3Auth/Web3Auth.swift
@@ -54,6 +54,9 @@ public class Web3Auth: NSObject {
     
     private func getLoginDetails(_ callbackURL: URL) async throws -> Web3AuthState {
         let loginDetailsDict = try await sessionManager.authorizeSession()
+        print("loginDetailsDict: \(loginDetailsDict)")
+        print("sessionID: \(sessionManager.getSessionID())")
+        print("network: \(initParams.network)")
         guard
             let loginDetails = Web3AuthState(dict: loginDetailsDict, sessionID: sessionManager.getSessionID() ?? "",network: initParams.network)
         else {

--- a/Sources/Web3Auth/Web3Auth.swift
+++ b/Sources/Web3Auth/Web3Auth.swift
@@ -54,9 +54,6 @@ public class Web3Auth: NSObject {
     
     private func getLoginDetails(_ callbackURL: URL) async throws -> Web3AuthState {
         let loginDetailsDict = try await sessionManager.authorizeSession()
-        print("loginDetailsDict: \(loginDetailsDict)")
-        print("sessionID: \(sessionManager.getSessionID())")
-        print("network: \(initParams.network)")
         guard
             let loginDetails = Web3AuthState(dict: loginDetailsDict, sessionID: sessionManager.getSessionID() ?? "",network: initParams.network)
         else {
@@ -157,8 +154,6 @@ public class Web3Auth: NSObject {
                         let callbackURL = callbackURL,
                         let sessionId = try? Web3Auth.decodeSessionStringfromCallbackURL(callbackURL)
                     else {
-
-                        print("Failed to decode decodeSessionStringfromCallbackURL")
                         let authError = authError ?? Web3AuthError.unknownError
                         if case ASWebAuthenticationSessionError.canceledLogin = authError {
                             continuation.resume(throwing: Web3AuthError.userCancelled)
@@ -171,9 +166,7 @@ public class Web3Auth: NSObject {
                     self.sessionManager.setSessionID(sessionId)
                     Task {
                         do {
-                            print("start get login details \(callbackURL)");
                             let loginDetails = try await self.getLoginDetails(callbackURL)
-                            print("end get login details");
                             if let safeUserInfo = loginDetails.userInfo {
                                 KeychainManager.shared.saveDappShare(userInfo: safeUserInfo)
                             }
@@ -181,8 +174,6 @@ public class Web3Auth: NSObject {
                             self.state = loginDetails
                             return continuation.resume(returning: loginDetails)
                         } catch {
-                            print("Failed to get login details");
-                            print("Error: \(error.localizedDescription)")
                             continuation.resume(throwing: Web3AuthError.unknownError)
                         }
                     }
@@ -191,7 +182,6 @@ public class Web3Auth: NSObject {
             authSession?.presentationContextProvider = self
 
             if !(authSession?.start() ?? false) {
-                print("Auth session start failed");
                 continuation.resume(throwing: Web3AuthError.unknownError)
             }
         })

--- a/Sources/Web3Auth/Web3AuthUserInfo.swift
+++ b/Sources/Web3Auth/Web3AuthUserInfo.swift
@@ -55,7 +55,7 @@ extension Web3AuthUserInfo {
     init?(dict: [String: Any]) {
         guard let typeOfLogin = dict["typeOfLogin"] else { return nil }
         self.typeOfLogin = typeOfLogin as? String
-        self.name = dict["name"] as? String ?? ""
+        name = dict["name"] as? String ?? ""
         profileImage = dict["profileImage"] as? String ?? ""
         aggregateVerifier = dict["aggregateVerifier"] as? String ?? ""
         verifier = dict["verifier"] as? String ?? ""

--- a/Sources/Web3Auth/Web3AuthUserInfo.swift
+++ b/Sources/Web3Auth/Web3AuthUserInfo.swift
@@ -53,10 +53,9 @@ public struct Web3AuthUserInfo: Codable {
 
 extension Web3AuthUserInfo {
     init?(dict: [String: Any]) {
-        guard let name = dict["name"],
-              let typeOfLogin = dict["typeOfLogin"] else { return nil }
-        self.name = name as? String
+        guard let typeOfLogin = dict["typeOfLogin"] else { return nil }
         self.typeOfLogin = typeOfLogin as? String
+        self.name = dict["name"] as? String ?? ""
         profileImage = dict["profileImage"] as? String ?? ""
         aggregateVerifier = dict["aggregateVerifier"] as? String ?? ""
         verifier = dict["verifier"] as? String ?? ""


### PR DESCRIPTION
Using firebase verifier, my user info does not have name only email address. This causes login to fail with a decode error because it is expecting that name is not null using the guard statement. This issue was originally raised here https://github.com/Web3Auth/web3auth-flutter-sdk/issues/57