### PR TITLE
Fix sessionTime typo in constructor

### DIFF
--- a/Sources/Web3Auth/Types.swift
+++ b/Sources/Web3Auth/Types.swift
@@ -158,7 +158,7 @@ public struct W3ALoginConfig: Codable {
 }
 
 public struct W3AInitParams: Codable {
-    public init(clientId: String, network: Network, buildEnv: BuildEnv? = BuildEnv.production, sdkUrl: URL? = URL(string: "https://auth.web3auth.io/v5")!, redirectUrl: String? = nil, loginConfig: [String: W3ALoginConfig]? = nil, whiteLabel: W3AWhiteLabelData? = nil, chainNamespace: ChainNamespace? = ChainNamespace.eip155, useCoreKitKey: Bool? = false, mfaSettings: MfaSettings? = nil, sessionTIme: Int = 86400) {
+    public init(clientId: String, network: Network, buildEnv: BuildEnv? = BuildEnv.production, sdkUrl: URL? = URL(string: "https://auth.web3auth.io/v5")!, redirectUrl: String? = nil, loginConfig: [String: W3ALoginConfig]? = nil, whiteLabel: W3AWhiteLabelData? = nil, chainNamespace: ChainNamespace? = ChainNamespace.eip155, useCoreKitKey: Bool? = false, mfaSettings: MfaSettings? = nil, sessionTime: Int = 86400) {
         self.clientId = clientId
         self.network = network
         self.buildEnv = buildEnv
@@ -169,7 +169,7 @@ public struct W3AInitParams: Codable {
         self.chainNamespace = chainNamespace
         self.useCoreKitKey = useCoreKitKey
         self.mfaSettings = mfaSettings
-        self.sessionTime = min(7 * 86400, sessionTIme)
+        self.sessionTime = min(7 * 86400, sessionTime)
     }
 
     public init(clientId: String, network: Network) {


### PR DESCRIPTION
## Description

`sessionTime` typo in constructor is not allowing Flutter SDK users to change the session time on iOS resulting always in default session time of 1 day. 

[Key sent from Dart](https://github.com/Web3Auth/web3auth-flutter-sdk/blob/3927eb49849364c181faa943d930e13b9e8fbe05/lib/input.dart#L262)

[The decoding for sessionTime will fail here on Flutter SDK]( https://github.com/Web3Auth/web3auth-flutter-sdk/blob/3927eb49849364c181faa943d930e13b9e8fbe05/ios/Classes/SwiftWeb3AuthFlutterPlugin.swift#L41)