### PR TITLE
pin: session-manager-swift 4.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "KeychainSwift", url: "https://github.com/evgenyneu/keychain-swift.git", from: "20.0.0"),
-        .package(name:"SessionManager",url: "https://github.com/Web3Auth/session-manager-swift.git",from: "4.0.2"),
+        .package(name:"SessionManager",url: "https://github.com/Web3Auth/session-manager-swift.git", .exact("4.0.2")),
         .package(name: "curvelib.swift", url: "https://github.com/tkey/curvelib.swift", from: "1.0.1"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
     ],

--- a/Web3Auth.podspec
+++ b/Web3Auth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = "Web3Auth"
-  spec.version       = "9.0.0"
+  spec.version       = "9.0.1"
   spec.platform      = :ios, "14.0"
   spec.summary       = "Torus Web3Auth SDK for iOS applications"
   spec.homepage      = "https://github.com/web3auth/web3auth-swift-sdk"


### PR DESCRIPTION
Due to incorrect tagging on dependency, 4.1.0 and 5.0.0 share the same commit hash, pinning temporarily

Tag as 9.0.1